### PR TITLE
Making `org-elp-deactivate` more subtle

### DIFF
--- a/org-elp.el
+++ b/org-elp.el
@@ -105,8 +105,8 @@
 (defun org-elp-deactivate ()
   "Deactivate previewing and remove the idle timer."
   (interactive)
-  (pop-to-buffer org-elp--preview-buffer)
-  (kill-buffer-and-window)
+  (with-current-buffer org-elp--preview-buffer
+      (kill-buffer-and-window))
   (message "Deactivating org-elp")
   (cancel-function-timers #'org-elp--preview))
 

--- a/org-elp.el
+++ b/org-elp.el
@@ -105,7 +105,8 @@
 (defun org-elp-deactivate ()
   "Deactivate previewing and remove the idle timer."
   (interactive)
-  (delete-other-windows)
+  (pop-to-buffer org-elp--preview-buffer)
+  (kill-buffer-and-window)
   (message "Deactivating org-elp")
   (cancel-function-timers #'org-elp--preview))
 


### PR DESCRIPTION
Deactivating `org-elp-mode` would kill all other windows in the current frame, which is almost never what we want.

Simply killing the equation preview buffer and window does what we want, without touching the other windows.